### PR TITLE
Use requires_component validators for wmbus

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -101,10 +101,22 @@ WMBUS_MQTT_SCHEMA = cv.Schema({
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_INFO_COMP_ID):                  cv.declare_id(InfoComponent),
     cv.GenerateID():                                   cv.declare_id(WMBusComponent),
-    cv.OnlyWith(CONF_MQTT_ID, "mqtt"):                 cv.use_id(mqtt.MQTTClientComponent),
-    cv.OnlyWith(CONF_TIME_ID, "time"):                 cv.use_id(time.RealTimeClock),
-    cv.OnlyWith(CONF_WIFI_REF, "wifi"):                cv.use_id(wifi.WiFiComponent),
-    cv.OnlyWith(CONF_ETH_REF, "ethernet"):             cv.use_id(ethernet.EthernetComponent),
+    cv.Optional(CONF_MQTT_ID):               cv.All(
+        cv.requires_component("mqtt"),
+        cv.use_id(mqtt.MQTTClientComponent),
+    ),
+    cv.Optional(CONF_TIME_ID):               cv.All(
+        cv.requires_component("time"),
+        cv.use_id(time.RealTimeClock),
+    ),
+    cv.Optional(CONF_WIFI_REF):              cv.All(
+        cv.requires_component("wifi"),
+        cv.use_id(wifi.WiFiComponent),
+    ),
+    cv.Optional(CONF_ETH_REF):               cv.All(
+        cv.requires_component("ethernet"),
+        cv.use_id(ethernet.EthernetComponent),
+    ),
     cv.Optional(CONF_MOSI_PIN,       default=13):      pins.internal_gpio_output_pin_schema,
     cv.Optional(CONF_MISO_PIN,       default=12):      pins.internal_gpio_input_pin_schema,
     cv.Optional(CONF_CLK_PIN,        default=14):      pins.internal_gpio_output_pin_schema,


### PR DESCRIPTION
## Summary
- refactor config validation to use cv.requires_component for MQTT, time, WiFi, and Ethernet references

## Testing
- `python -m py_compile components/wmbus/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6d01cd43083269ff14bddbd12ab05