### PR TITLE
Use consolidated WiFi header

### DIFF
--- a/components/wmbus/wmbus.h
+++ b/components/wmbus/wmbus.h
@@ -29,8 +29,7 @@
 
 #include "utils.h"
 
-#include <WiFiClient.h>
-#include <WiFiUdp.h>
+#include <WiFi.h>
 
 
 namespace esphome {


### PR DESCRIPTION
## Summary
- include WiFi.h for both WiFiClient and WiFiUDP

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `g++ -std=c++14 -Icomponents -c components/wmbus/wmbus.cpp` *(fails: esphome/core/log.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0126ee8832694a9d3a0b73dfcde