### PR TITLE
Use internal pin schemas for WMBus SPI pins

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -103,12 +103,6 @@ CONFIG_SCHEMA = cv.Schema({
     cv.OnlyWith(CONF_TIME_ID, "time"):                 cv.use_id(time.RealTimeClock),
     cv.OnlyWith(CONF_WIFI_REF, "wifi"):                cv.use_id(wifi.WiFiComponent),
     cv.OnlyWith(CONF_ETH_REF, "ethernet"):             cv.use_id(ethernet.EthernetComponent),
-    cv.Optional(CONF_MOSI_PIN,       default=13):      pins.gpio_output_pin_schema(allow_internal=True),
-    cv.Optional(CONF_MISO_PIN,       default=12):      pins.gpio_input_pin_schema(allow_internal=True),
-    cv.Optional(CONF_CLK_PIN,        default=14):      pins.gpio_output_pin_schema(allow_internal=True),
-    cv.Optional(CONF_CS_PIN,         default=2):       pins.gpio_output_pin_schema(allow_internal=True),
-    cv.Optional(CONF_GDO0_PIN,       default=5):       pins.gpio_input_pin_schema(allow_internal=True),
-    cv.Optional(CONF_GDO2_PIN,       default=4):       pins.gpio_input_pin_schema(allow_internal=True),
     cv.Optional(CONF_MQTT_ID):               cv.All(
         cv.requires_component("mqtt"),
         cv.use_id(mqtt.MQTTClientComponent),


### PR DESCRIPTION
## Summary
- Simplify WMBus CONFIG_SCHEMA to rely solely on internal GPIO pin schemas for MOSI, MISO, CLK, CS, GDO0, and GDO2

## Testing
- `python -m py_compile components/wmbus/__init__.py`
- `pytest`
- `python - <<'PY'
try:
    import components.wmbus
    print('import succeeded')
except Exception as e:
    print('import failed:', e)
PY` *(fails: No module named 'esphome')*

------
https://chatgpt.com/codex/tasks/task_e_68a6fa7dcf848326b8994ed21fe2dc2e