### PR TITLE
Remove deprecated loop stack size API usage

### DIFF
--- a/components/wmbus/wmbus.cpp
+++ b/components/wmbus/wmbus.cpp
@@ -27,7 +27,9 @@ namespace wmbus {
 
   void WMBusComponent::setup() {
 #ifdef USE_ESP32
-    App.set_loop_task_stack_size(32 * 1024);
+    // App.set_loop_task_stack_size() has been removed from ESPHome.
+    // If additional stack space is required, adjust it via ESPHome build
+    // flags or the current API for configuring the main loop stack.
 #endif
     this->high_freq_.start();
     if (this->led_pin_ != nullptr) {


### PR DESCRIPTION
## Summary
- drop `App.set_loop_task_stack_size()` in WMBusComponent
- note that stack size should now be configured via ESPHome build flags or newer API

## Testing
- `g++ -std=c++17 -fsyntax-only components/wmbus/wmbus.cpp` *(fails: esphome/core/log.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fddb58448326a5ffead263e10dc1