### PR TITLE
Remove deprecated loop stack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ sensor:
 #### 2.1.2. Example
 
 ```yaml
+esp32:
+  core_loop_stack_size: 32768
+
 time:
   - platform: sntp
     id: time_sntp

--- a/components/wmbus/wmbus.cpp
+++ b/components/wmbus/wmbus.cpp
@@ -26,9 +26,10 @@ namespace wmbus {
   }
 
   void WMBusComponent::setup() {
-#ifdef USE_ESP32
-    App.set_loop_task_stack_size(32 * 1024);
-#endif
+    // Ensure sufficient stack for the main loop; configure in YAML using
+    // `esp32:
+    //   core_loop_stack_size: 32768`
+    // when building for ESP32.
     this->high_freq_.start();
     if (this->led_pin_ != nullptr) {
       this->led_pin_->setup();

--- a/docs/version_3.md
+++ b/docs/version_3.md
@@ -33,6 +33,9 @@ https://github.com/SzczepanLeon/esphome-components/blob/main/docs/wmbus.md
 #### 2.1.1. Example
 
 ```yaml
+esp32:
+  core_loop_stack_size: 32768
+
 time:
   - platform: sntp
     id: time_sntp


### PR DESCRIPTION
## Summary
- drop outdated `App.set_loop_task_stack_size` usage
- document required `esp32.core_loop_stack_size` setting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6fdd465ec8326b65fc5a8630cc93c