### PR TITLE
Add explicit one-wire bus id for Dallas temperature sensors

### DIFF
--- a/docs/dallas_example.yaml
+++ b/docs/dallas_example.yaml
@@ -1,0 +1,13 @@
+one_wire:
+  pin: GPIO4
+  id: ow_bus
+
+sensor:
+  - platform: dallas_temp
+    address: 0x1234567890abcdef
+    name: "Temperature 1"
+    one_wire_id: ow_bus
+  - platform: dallas_temp
+    address: 0xfedcba9876543210
+    name: "Temperature 2"
+    one_wire_id: ow_bus


### PR DESCRIPTION
## Summary
- add example configuration that assigns an `id` to the `one_wire` bus
- reference the one-wire bus from each `dallas_temp` sensor using `one_wire_id`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6fdfba70483269f3632ea6a9aedfc