### PR TITLE
Add time_id to wmbus documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ wmbus:
   all_drivers: False
   sync_mode: True
   log_all: True
+  time_id: time_sntp
 
   mqtt:
     broker: 10.0.0.88
@@ -240,6 +241,7 @@ In wmbus platform:
 - **led_blink_time** (*Optional*): How long LED will stay ON. Defaults to ``300 ms``.
 - **frequency** (*Optional*): Rx frequency in MHz. Defaults to ``868.950 MHz``.
 - **sync_mode** (*Optional*): Receive telegram in one loop. Defaults to ``False``.
+- **time_id** (**Required**): ID of time source component from the `time:` section.
 - **log_all** (*Optional*): Show all received telegrams in log. Defaults to ``False``.
 - **all_drivers** (*Optional*): Compile with all drivers. Defaults to ``False``.
 - **clients** (*Optional*):

--- a/docs/version_3.md
+++ b/docs/version_3.md
@@ -52,6 +52,7 @@ wmbus:
 
   led_pin: GPIO0
   led_blink_time: "1s"
+  time_id: time_sntp
 
   clients:
     - name: "wmbusmeters"
@@ -110,6 +111,7 @@ In wmbus platform:
 
 - **frequency** (*Optional*): CC1101 Rx frequency in MHz. Defaults to ``868.950 MHz``.
 - **sync_mode** (*Optional*): If you have problems with MQTT set it to True. Defaults to ``False``.
+- **time_id** (**Required**): ID of time source component from the `time:` section.
 - **mosi_pin** (*Optional*): CC1101 MOSI pin connection. Defaults to ``GPIO13``.
 - **miso_pin** (*Optional*): CC1101 MISO pin connection. Defaults to ``GPIO12``.
 - **clk_pin** (*Optional*): CC1101 CLK pin connection. Defaults to ``GPIO14``.


### PR DESCRIPTION
## Summary
- document specifying time source for wmbus via time_id

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6fdf8b11083269481356da8fc4921