### PR TITLE
Parse key for apatorna1 driver

### DIFF
--- a/components/wmbus/driver_apatorna1.cpp
+++ b/components/wmbus/driver_apatorna1.cpp
@@ -57,8 +57,13 @@ namespace
         vector<uchar> frame(content.begin() + 2, content.begin() + 18);
         vector<uchar>::iterator pos = frame.begin();
 
-        // TODO: read specified key from input
-        vector<uchar> aes_key(16, 0);
+        vector<uchar> aes_key = meterKeys()->confidentiality_key;
+        if (aes_key.size() != 16)
+        {
+            warning("(apatorna1) invalid or missing AES key, expected 16 bytes");
+            t->decryption_failed = true;
+            return;
+        }
 
         int num_encrypted_bytes = 0;
         int num_not_encrypted_at_end = 0;

--- a/docs/wmbus.md
+++ b/docs/wmbus.md
@@ -74,17 +74,22 @@ device=rtlwmbus:CMD(mosquitto_sub -h broker.local -t someprefix/+/wmbus/raw)
 
 Add meters:
 ```yaml
-meters:  
-  - |-  
-    name=water_from_izar  
-    driver=izar  
-    id=123456  
-    key=  
-  - |-  
-    name=water_from_apator  
-    driver=apator162  
-    id=9876543  
+meters:
+  - |-
+    name=water_from_izar
+    driver=izar
+    id=123456
+    key=
+  - |-
+    name=water_from_apator
+    driver=apator162
+    id=9876543
     key=00000000000000000000000000000000
+  - |-
+    name=water_from_apatorna1
+    driver=apatorna1
+    id=04913581
+    key=00112233445566778899AABBCCDDEEFF
 ```
 
 Add MQTT configuration:

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -22,3 +22,13 @@ wmbus:
   all_drivers: False
   sync_mode: True
   log_all: True
+
+sensor:
+  - platform: wmbus
+    meter_id: 0x04913581
+    type: apatorna1
+    key: "00112233445566778899AABBCCDDEEFF"
+    sensors:
+      - name: "apatorna1 water"
+        field: "total"
+        unit_of_measurement: "m³"


### PR DESCRIPTION
## Summary
- Parse and validate AES key for apatorna1 meter instead of using zero bytes
- Document key usage in configuration examples

## Testing
- `g++ -std=c++17 -Icomponents/wmbus -c components/wmbus/driver_apatorna1.cpp` *(fails: esphome/core/log.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7060bfd088326853cdda80706555c