### PR TITLE
Handle SAP PRIOS Standard address frames

### DIFF
--- a/components/wmbus/manufacturer_specificities.cpp
+++ b/components/wmbus/manufacturer_specificities.cpp
@@ -159,7 +159,30 @@ void transformDiehlAddress(vector<uchar>& frame, DiehlAddressTransformMethod tra
     }
     else if (transform_method == DiehlAddressTransformMethod::SAP_PRIOS_STANDARD)
     {
-        warning("(diehl) Pre-processing: SAP PRIOS STANDARD transformation not implemented!"); // TODO
+        // SAP PRIOS "standard" frames encode the address with the
+        // version/type first and without providing the device type.
+        // To make the address compliant with the M-Bus standard we
+        // need to swap the fields and force the device type to water
+        // meter (type 0x07, version 0x00).
+        debug("(diehl) Pre-processing: swapping address field and setting device type to water meter for SAP PRIOS STANDARD");
+
+        // Keep a copy of the original address for debugging
+        vector<uchar> original(frame.begin() + 4, frame.begin() + 10);
+
+        // First swap version/type with the serial number (same as in
+        // the generic PRIOS transformation)
+        for (int i = 4; i < 8; ++i)
+        {
+            frame[i] = frame[i + 2];
+        }
+
+        // Force version and type values missing from the telegram
+        frame[8] = 0x00; // version is not transmitted
+        frame[9] = 0x07; // water meter
+
+        debug("(diehl) Address before: %s after: %s",
+              bin2hex(original).c_str(),
+              bin2hex(vector<uchar>(frame.begin() + 4, frame.begin() + 10)).c_str());
     }
 }
 

--- a/components/wmbus/manufacturer_specificities.h
+++ b/components/wmbus/manufacturer_specificities.h
@@ -62,7 +62,7 @@ enum class DiehlAddressTransformMethod {
     NONE,              // "A field" coded as per standard
     SWAPPING,          // "A field" coded as version/type/serialnumber instead of standard serialnumber/version/type
     SAP_PRIOS,         // Version and type not included in telegram. Must be hardcoded to 0 and 7
-    SAP_PRIOS_STANDARD // ?
+    SAP_PRIOS_STANDARD // Version/type first and missing; swap and force water meter
 };
 
 const char* toString(DiehlAddressTransformMethod m);


### PR DESCRIPTION
## Summary
- add address transformation for SAP PRIOS STANDARD frames
- document SAP PRIOS STANDARD address handling

## Testing
- `g++ -std=c++17 -Icomponents/wmbus -I/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages -c components/wmbus/manufacturer_specificities.cpp -o /tmp/man.o`


------
https://chatgpt.com/codex/tasks/task_e_68a7060a77a88326b6a50d1349296ef2