### PR TITLE
Handle T1 B frames in mBusDecode

### DIFF
--- a/components/wmbus/mbus.cpp
+++ b/components/wmbus/mbus.cpp
@@ -32,30 +32,58 @@ namespace wmbus {
       }
     }
     else if (t_in.mode == 'T') {
-      ESP_LOGD(TAG, "Received T1 A frame");
-      std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
-      std::string telegram = format_hex_pretty(rawFrame);
-      telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
-      if (telegram.size() > 400) {  // ToDo: rewrite
-        std::string tel_01 = telegram.substr(0,400);
-        ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
-        std::string tel_02 = telegram.substr(400,800);
-        ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
-      }
-      else {
-        ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
-      }
-
-      if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
-        std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
-        std::string telegram = format_hex_pretty(frame);
+      if (t_in.block == 'A') {
+        ESP_LOGD(TAG, "Received T1 A frame");
+        std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
+        std::string telegram = format_hex_pretty(rawFrame);
         telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
-        ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
-        if (mBusDecodeFormatA(t_in, t_frame)) {
-          retVal = true;
+        if (telegram.size() > 400) {  // ToDo: rewrite
+          std::string tel_01 = telegram.substr(0,400);
+          ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
+          std::string tel_02 = telegram.substr(400,800);
+          ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
+        }
+        else {
+          ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
+        }
+
+        if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
+          std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
+          std::string telegram = format_hex_pretty(frame);
+          telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
+          ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
+          ESP_LOGD(TAG, "Decoding T1 A format");
+          if (mBusDecodeFormatA(t_in, t_frame)) {
+            retVal = true;
+          }
         }
       }
+      else if (t_in.block == 'B') {
+        ESP_LOGD(TAG, "Received T1 B frame");
+        std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
+        std::string telegram = format_hex_pretty(rawFrame);
+        telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
+        if (telegram.size() > 400) {  // ToDo: rewrite
+          std::string tel_01 = telegram.substr(0,400);
+          ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
+          std::string tel_02 = telegram.substr(400,800);
+          ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
+        }
+        else {
+          ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
+        }
 
+        if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
+          std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
+          std::string telegram = format_hex_pretty(frame);
+          telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
+          ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
+          ESP_LOGD(TAG, "Decoding T1 B format");
+          if (mBusDecodeFormatB(t_in, t_frame)) {
+            retVal = true;
+          }
+        }
+      }
     }
     if (retVal) {
       std::string telegram = format_hex_pretty(t_frame.frame);


### PR DESCRIPTION
## Summary
- Inspect `t_in.block` for T-mode telegrams
- Decode and log T1 B frames using Format B

## Testing
- `g++ tests/datetime_flags_test.cpp -std=c++17 -o tests/datetime_flags_test && ./tests/datetime_flags_test`
- `g++ tests/render_analysis_json_test.cpp -std=c++17 -o tests/render_analysis_json_test && ./tests/render_analysis_json_test`


------
https://chatgpt.com/codex/tasks/task_e_68a730a172888326bf53ffedc0c8b574