### PR TITLE
Handle AES key and decryption failures in apator162 driver

### DIFF
--- a/components/wmbus/driver_apator162.cpp
+++ b/components/wmbus/driver_apator162.cpp
@@ -72,6 +72,21 @@ namespace
         vector<uchar> content;
         t->extractPayload(&content);
 
+        vector<uchar> aes_key = meterKeys()->confidentiality_key;
+        if (aes_key.size() != 16)
+        {
+            warning("(apator162) invalid or missing AES key, expected 16 bytes");
+            t->decryption_failed = true;
+            return;
+        }
+
+        if (t->decryption_failed)
+        {
+            error("(apator162) failed to decrypt telegram");
+            t->discard = true;
+            return;
+        }
+
         map<string,pair<int,DVEntry>> vendor_values;
 
         // The first 8 bytes are error flags and a date time.


### PR DESCRIPTION
## Summary
- validate confidentiality key length before processing apator162 telegrams
- log and abort when decryption fails to avoid processing invalid data

## Testing
- `g++ -std=c++17 -Icomponents/wmbus -I/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages -c components/wmbus/driver_apator162.cpp`
- `g++ -std=c++17 tests/datetime_flags_test.cpp -o datetime_flags_test && ./datetime_flags_test`
- `g++ -std=c++17 tests/render_analysis_json_test.cpp -o render_analysis_json_test && ./render_analysis_json_test`


------
https://chatgpt.com/codex/tasks/task_e_68a730a62fd083269a545698dbd0aae6