### PR TITLE
Refactor mBusDecode mode handling

### DIFF
--- a/components/wmbus/mbus.cpp
+++ b/components/wmbus/mbus.cpp
@@ -33,87 +33,59 @@ bool mBusDecode(WMbusData &t_in, WMbusFrame &t_frame) {
         retVal = true;
       }
     }
-    else if (t_in.mode == 'T') {
-      if (t_in.block == 'A') {
-        ESP_LOGD(TAG, "Received T1 A frame");
-        std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
-        std::string telegram = format_hex_pretty(rawFrame);
-        telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
-        if (telegram.size() > 400) {  // ToDo: rewrite
-          std::string tel_01 = telegram.substr(0,400);
-          ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
-          std::string tel_02 = telegram.substr(400,800);
-          ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
-        }
-        else {
-          ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
-        }
-
-        if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
-          std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
-          std::string telegram = format_hex_pretty(frame);
-          telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
-          ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
-          ESP_LOGD(TAG, "Decoding T1 A format");
-          if (mBusDecodeFormatA(t_in, t_frame)) {
-            retVal = true;
-          }
-        }
-      }
-      else if (t_in.block == 'B') {
-        ESP_LOGD(TAG, "Received T1 B frame");
-        std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
-        std::string telegram = format_hex_pretty(rawFrame);
-        telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
-        if (telegram.size() > 400) {  // ToDo: rewrite
-          std::string tel_01 = telegram.substr(0,400);
-          ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
-          std::string tel_02 = telegram.substr(400,800);
-          ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
-        }
-        else {
-          ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
-        }
-
-        if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
-          std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
-          std::string telegram = format_hex_pretty(frame);
-          telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
-          ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
-          ESP_LOGD(TAG, "Decoding T1 B format");
-          if (mBusDecodeFormatB(t_in, t_frame)) {
-            retVal = true;
-          }
-        }
-      }
   } else if (t_in.mode == 'T') {
-    ESP_LOGD(TAG, "Received T1 A frame");
-    std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
-    std::string telegram = format_hex_pretty(rawFrame);
-    telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'),
-                   telegram.end());
-    if (telegram.size() > 400) { // ToDo: rewrite
-      std::string tel_01 = telegram.substr(0, 400);
-      ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
-      std::string tel_02 = telegram.substr(400, 800);
-      ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
-    } else {
-      ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
-    }
-
-    if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
-      std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
-      std::string telegram = format_hex_pretty(frame);
+    if (t_in.block == 'A') {
+      ESP_LOGD(TAG, "Received T1 A frame");
+      std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
+      std::string telegram = format_hex_pretty(rawFrame);
       telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'),
                      telegram.end());
-      ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
-      if (mBusDecodeFormatA(t_in, t_frame)) {
-        retVal = true;
+      if (telegram.size() > 400) {  // ToDo: rewrite
+        std::string tel_01 = telegram.substr(0, 400);
+        ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
+        std::string tel_02 = telegram.substr(400, 800);
+        ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
       } else {
-        ESP_LOGW(TAG, "frame decryption failed");
+        ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
       }
-    } else {
-      ESP_LOGW(TAG, "frame decryption failed");
+
+      if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
+        std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
+        std::string telegram = format_hex_pretty(frame);
+        telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'),
+                       telegram.end());
+        ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
+        ESP_LOGD(TAG, "Decoding T1 A format");
+        if (mBusDecodeFormatA(t_in, t_frame)) {
+          retVal = true;
+        }
+      }
+    } else if (t_in.block == 'B') {
+      ESP_LOGD(TAG, "Received T1 B frame");
+      std::vector<unsigned char> rawFrame(t_in.data, t_in.data + t_in.length);
+      std::string telegram = format_hex_pretty(rawFrame);
+      telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'),
+                     telegram.end());
+      if (telegram.size() > 400) {  // ToDo: rewrite
+        std::string tel_01 = telegram.substr(0, 400);
+        ESP_LOGV(TAG, "Frame: %s [RAW]", tel_01.c_str());
+        std::string tel_02 = telegram.substr(400, 800);
+        ESP_LOGV(TAG, "       %s [RAW]", tel_02.c_str());
+      } else {
+        ESP_LOGV(TAG, "Frame: %s [RAW]", telegram.c_str());
+      }
+
+      if (decode3OutOf6(&t_in, packetSize(t_in.lengthField))) {
+        std::vector<unsigned char> frame(t_in.data, t_in.data + t_in.length);
+        std::string telegram = format_hex_pretty(frame);
+        telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'),
+                       telegram.end());
+        ESP_LOGV(TAG, "Frame: %s [with CRC]", telegram.c_str());
+        ESP_LOGD(TAG, "Decoding T1 B format");
+        if (mBusDecodeFormatB(t_in, t_frame)) {
+          retVal = true;
+        }
+      }
     }
   }
   if (retVal) {


### PR DESCRIPTION
## Summary
- restructure mBusDecode to handle 'C' and 'T' modes as top-level branches
- remove nested mode check inside 'C'
- ensure mBusDecode closes cleanly before other decoders

## Testing
- `make clean && make` *(fails: t does not name a type in driver_apator162.cpp)*
- `g++ -std=c++17 -c components/wmbus/mbus.cpp -Icomponents/wmbus` *(fails: esphome/core/helpers.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a733feb12c8326ad7070be9f269f6c