### PR TITLE
Optimize WMBus driver compilation by centralizing build filters

### DIFF
--- a/components/wmbus/sensor/__init__.py
+++ b/components/wmbus/sensor/__init__.py
@@ -20,7 +20,8 @@ CONF_SENSORS = 'sensors'
 
 from .. import (
     WMBusComponent,
-    wmbus_ns
+    wmbus_ns,
+    register_driver,
 )
 from ..common import my_key
 
@@ -50,7 +51,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 async def to_code(config):
     if config[CONF_TYPE]:
-        cg.add_platformio_option("build_src_filter", [f"+<**/wmbus/driver_{config[CONF_TYPE].lower()}.cpp>"])
+        register_driver(config[CONF_TYPE])
     if config[CONF_METER_ID]:
         wmbus = await cg.get_variable(config[CONF_WMBUS_ID])
         cg.add(wmbus.register_wmbus_listener(config[CONF_METER_ID], config[CONF_TYPE].lower(), config[CONF_KEY]))

--- a/components/wmbus/text_sensor/__init__.py
+++ b/components/wmbus/text_sensor/__init__.py
@@ -19,7 +19,8 @@ CONF_SENSORS = 'sensors'
 
 from .. import (
     WMBusComponent,
-    wmbus_ns
+    wmbus_ns,
+    register_driver,
 )
 from ..common import my_key
 
@@ -49,7 +50,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 async def to_code(config):
     if config[CONF_TYPE]:
-        cg.add_platformio_option("build_src_filter", [f"+<**/wmbus/driver_{config[CONF_TYPE].lower()}.cpp>"])
+        register_driver(config[CONF_TYPE])
     if config[CONF_METER_ID]:
         wmbus = await cg.get_variable(config[CONF_WMBUS_ID])
         cg.add(wmbus.register_wmbus_listener(config[CONF_METER_ID], config[CONF_TYPE].lower(), config[CONF_KEY]))


### PR DESCRIPTION
## Summary
- Track required WMBus drivers in a registry and build only those sources
- Update sensor and text_sensor to register their driver dependencies
- Apply build_src_filter once with the consolidated driver list

## Testing
- `pytest -q`
- `python -m py_compile components/wmbus/__init__.py components/wmbus/sensor/__init__.py components/wmbus/text_sensor/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a763898788832683e5b74a780f1df3