### PR TITLE
Use CORE.add_job for build src filter

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -7,6 +7,7 @@ from esphome.components import mqtt
 from esphome.components import wifi
 from esphome.components import ethernet
 from esphome.components.network import IPAddress
+from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
     CONF_MOSI_PIN,
@@ -232,4 +233,4 @@ async def to_code(config):
             filters.append("+<**/wmbus/driver_unknown.cpp>")
         cg.add_platformio_option("build_src_filter", filters)
 
-    cg.add_job(_apply_build_src_filter)
+    CORE.add_job(_apply_build_src_filter)


### PR DESCRIPTION
## Summary
- schedule build_src_filter job with esphome.core.CORE

## Testing
- `make test`
- `python - <<'PY'
import esphome.codegen as cg
from esphome.core import CORE

def _apply_build_src_filter():
    cg.add_platformio_option('build_src_filter', ['foo'])

CORE.add_job(_apply_build_src_filter)
CORE.flush_tasks()
print('platformio_options', CORE.platformio_options)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a765aa1534832696b20114606a36b0