### PR TITLE
refactor: add CC1101 driver abstraction

### DIFF
--- a/components/wmbus/rf_cc1101.cpp
+++ b/components/wmbus/rf_cc1101.cpp
@@ -5,51 +5,85 @@ namespace wmbus {
 
   static const char *TAG = "rxLoop";
 
+  bool Cc1101Driver::begin(uint8_t mosi, uint8_t miso, uint8_t clk, uint8_t cs) {
+    ELECHOUSE_cc1101.setSpiPin(clk, miso, mosi, cs);
+    ELECHOUSE_cc1101.Init();
+    for (uint8_t i = 0; i < TMODE_RF_SETTINGS_LEN; i++) {
+      ELECHOUSE_cc1101.SpiWriteReg(TMODE_RF_SETTINGS_BYTES[i << 1],
+                                   TMODE_RF_SETTINGS_BYTES[(i << 1) + 1]);
+    }
+    return true;
+  }
+
+  bool Cc1101Driver::set_frequency(float mhz) {
+    uint32_t freq_reg = uint32_t(mhz * 65536 / 26);
+    uint8_t freq2 = (freq_reg >> 16) & 0xFF;
+    uint8_t freq1 = (freq_reg >> 8) & 0xFF;
+    uint8_t freq0 = freq_reg & 0xFF;
+    ESP_LOGD(TAG, "Set CC1101 frequency to %3.3fMHz [%02X %02X %02X]", mhz, freq2, freq1, freq0);
+    ELECHOUSE_cc1101.SpiWriteReg(CC1101_FREQ2, freq2);
+    ELECHOUSE_cc1101.SpiWriteReg(CC1101_FREQ1, freq1);
+    ELECHOUSE_cc1101.SpiWriteReg(CC1101_FREQ0, freq0);
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_SCAL);
+    byte cc1101Version = ELECHOUSE_cc1101.SpiReadStatus(CC1101_VERSION);
+    if ((cc1101Version == 0) || (cc1101Version == 255)) {
+      return false;
+    }
+    ELECHOUSE_cc1101.SetRx();
+    delay(4);
+    return true;
+  }
+
+  bool Cc1101Driver::read_frame(uint8_t *buffer, uint8_t length) {
+    ELECHOUSE_cc1101.SpiReadBurstReg(CC1101_RXFIFO, buffer, length);
+    return true;
+  }
+
+  bool Cc1101Driver::write_register(uint8_t reg, uint8_t value) {
+    ELECHOUSE_cc1101.SpiWriteReg(reg, value);
+    return true;
+  }
+
+  uint8_t Cc1101Driver::read_status(uint8_t reg) {
+    return ELECHOUSE_cc1101.SpiReadStatus(reg);
+  }
+
+  bool Cc1101Driver::strobe(uint8_t cmd) {
+    ELECHOUSE_cc1101.SpiStrobe(cmd);
+    return true;
+  }
+
+  void Cc1101Driver::set_rx() {
+    ELECHOUSE_cc1101.SetRx();
+  }
+
+  int8_t Cc1101Driver::get_rssi() {
+    return (int8_t)ELECHOUSE_cc1101.getRssi();
+  }
+
+  uint8_t Cc1101Driver::get_lqi() {
+    return (uint8_t)ELECHOUSE_cc1101.getLqi();
+  }
+
   bool RxLoop::init(uint8_t mosi, uint8_t miso, uint8_t clk, uint8_t cs,
                     uint8_t gdo0, uint8_t gdo2, float freq, bool syncMode) {
-    bool retVal = false;
     this->syncMode = syncMode;
     this->gdo0 = gdo0;
     this->gdo2 = gdo2;
     pinMode(this->gdo0, INPUT);
     pinMode(this->gdo2, INPUT);
-    ELECHOUSE_cc1101.setSpiPin(clk, miso, mosi, cs);
 
-    ELECHOUSE_cc1101.Init();
-
-    for (uint8_t i = 0; i < TMODE_RF_SETTINGS_LEN; i++) {
-      ELECHOUSE_cc1101.SpiWriteReg(TMODE_RF_SETTINGS_BYTES[i << 1],
-                                   TMODE_RF_SETTINGS_BYTES[(i << 1) + 1]);
-    }
-
-    uint32_t freq_reg = uint32_t(freq * 65536 / 26);
-    uint8_t freq2 = (freq_reg >> 16) & 0xFF;
-    uint8_t freq1 = (freq_reg >> 8) & 0xFF;
-    uint8_t freq0 = freq_reg & 0xFF;
-
-    ESP_LOGD(TAG, "Set CC1101 frequency to %3.3fMHz [%02X %02X %02X]",
-             freq/1.0, freq2, freq1, freq0);
-             // don't use setMHZ() -- seems to be broken, or used in wrong place
-    ELECHOUSE_cc1101.SpiWriteReg(CC1101_FREQ2, freq2);
-    ELECHOUSE_cc1101.SpiWriteReg(CC1101_FREQ1, freq1);
-    ELECHOUSE_cc1101.SpiWriteReg(CC1101_FREQ0, freq0);
-
-    ELECHOUSE_cc1101.SpiStrobe(CC1101_SCAL);
-
-    byte cc1101Version = ELECHOUSE_cc1101.SpiReadStatus(CC1101_VERSION);
-
-    if ((cc1101Version != 0) && (cc1101Version != 255)) {
-      retVal = true;
-      ESP_LOGD(TAG, "CC1101 version '%d'", cc1101Version);
-      ELECHOUSE_cc1101.SetRx();
-      ESP_LOGD(TAG, "CC1101 initialized");
-      delay(4);
-    }
-    else {
+    if (!cc1101_.begin(mosi, miso, clk, cs)) {
       ESP_LOGE(TAG, "CC1101 initialization FAILED!");
+      return false;
+    }
+    if (!cc1101_.set_frequency(freq)) {
+      ESP_LOGE(TAG, "CC1101 set frequency FAILED!");
+      return false;
     }
 
-    return retVal;
+    ESP_LOGD(TAG, "CC1101 initialized");
+    return true;
   }
 
   bool RxLoop::task() {
@@ -72,7 +106,7 @@ namespace wmbus {
           if (digitalRead(this->gdo0)) { // assert when Rx FIFO buffer threshold reached
             uint8_t preamble[2];
             // Read the 3 first bytes,
-            ELECHOUSE_cc1101.SpiReadBurstReg(CC1101_RXFIFO, rxLoop.pByteIndex, 3);
+            cc1101_.read_frame(rxLoop.pByteIndex, 3);
             rxLoop.bytesRx = 3;
             const uint8_t *currentByte = rxLoop.pByteIndex;
             // Mode C
@@ -121,19 +155,19 @@ namespace wmbus {
 
             if (rxLoop.length < MAX_FIXED_LENGTH) {
               // Set CC1101 into length mode
-              ELECHOUSE_cc1101.SpiWriteReg(CC1101_PKTLEN, (uint8_t)rxLoop.length);
-              ELECHOUSE_cc1101.SpiWriteReg(CC1101_PKTCTRL0, FIXED_PACKET_LENGTH);
+              cc1101_.write_register(CC1101_PKTLEN, (uint8_t)rxLoop.length);
+              cc1101_.write_register(CC1101_PKTCTRL0, FIXED_PACKET_LENGTH);
               rxLoop.cc1101Mode = FIXED;
             }
             else {
               // Set CC1101 into infinite mode
-              ELECHOUSE_cc1101.SpiWriteReg(CC1101_PKTLEN, (uint8_t)(rxLoop.length%MAX_FIXED_LENGTH));
+              cc1101_.write_register(CC1101_PKTLEN, (uint8_t)(rxLoop.length%MAX_FIXED_LENGTH));
             }
 
             rxLoop.state = READ_DATA;
             max_wait_time_ += extra_time_;
 
-            ELECHOUSE_cc1101.SpiWriteReg(CC1101_FIFOTHR, RX_FIFO_THRESHOLD);
+            cc1101_.write_register(CC1101_FIFOTHR, RX_FIFO_THRESHOLD);
           }
           break;
 
@@ -141,12 +175,12 @@ namespace wmbus {
         case READ_DATA:
           if (digitalRead(this->gdo0)) { // assert when Rx FIFO buffer threshold reached
             if ((rxLoop.bytesLeft < MAX_FIXED_LENGTH) && (rxLoop.cc1101Mode == INFINITE)) {
-              ELECHOUSE_cc1101.SpiWriteReg(CC1101_PKTCTRL0, FIXED_PACKET_LENGTH);
+              cc1101_.write_register(CC1101_PKTCTRL0, FIXED_PACKET_LENGTH);
               rxLoop.cc1101Mode = FIXED;
             }
             // Do not empty the Rx FIFO (See the CC1101 SWRZ020E errata note)
-            uint8_t bytesInFIFO = ELECHOUSE_cc1101.SpiReadStatus(CC1101_RXBYTES) & 0x7F;
-            ELECHOUSE_cc1101.SpiReadBurstReg(CC1101_RXFIFO, rxLoop.pByteIndex, bytesInFIFO - 1);
+            uint8_t bytesInFIFO = cc1101_.read_status(CC1101_RXBYTES) & 0x7F;
+            cc1101_.read_frame(rxLoop.pByteIndex, bytesInFIFO - 1);
 
             rxLoop.bytesLeft  -= (bytesInFIFO - 1);
             rxLoop.pByteIndex += (bytesInFIFO - 1);
@@ -156,14 +190,14 @@ namespace wmbus {
           break;
       }
 
-      uint8_t overfl = ELECHOUSE_cc1101.SpiReadStatus(CC1101_RXBYTES) & 0x80;
+      uint8_t overfl = cc1101_.read_status(CC1101_RXBYTES) & 0x80;
       // end of packet in length mode
       if ((!overfl) && (!digitalRead(gdo2))  && (rxLoop.state > WAIT_FOR_DATA)) {
-        ELECHOUSE_cc1101.SpiReadBurstReg(CC1101_RXFIFO, rxLoop.pByteIndex, (uint8_t)rxLoop.bytesLeft);
+        cc1101_.read_frame(rxLoop.pByteIndex, (uint8_t)rxLoop.bytesLeft);
         rxLoop.bytesRx += rxLoop.bytesLeft;
         data_in.length  = rxLoop.bytesRx;
-        this->returnFrame.rssi  = (int8_t)ELECHOUSE_cc1101.getRssi();
-        this->returnFrame.lqi   = (uint8_t)ELECHOUSE_cc1101.getLqi();
+        this->returnFrame.rssi  = cc1101_.get_rssi();
+        this->returnFrame.lqi   = cc1101_.get_lqi();
         ESP_LOGV(TAG, "Have %d bytes from CC1101 Rx, RSSI: %d dBm LQI: %d", rxLoop.bytesRx, this->returnFrame.rssi, this->returnFrame.lqi);
         if (rxLoop.length != data_in.length) {
           ESP_LOGE(TAG, "Length problem: req(%d) != rx(%d)", rxLoop.length, data_in.length);
@@ -194,7 +228,7 @@ namespace wmbus {
     if (!force) {
       if (!reinit_needed) {
         // already in RX?
-        if (ELECHOUSE_cc1101.SpiReadStatus(CC1101_MARCSTATE) == MARCSTATE_RX) {
+        if (cc1101_.read_status(CC1101_MARCSTATE) == MARCSTATE_RX) {
           return false;
         }
       }
@@ -204,10 +238,10 @@ namespace wmbus {
     sync_time_ = millis();
     max_wait_time_ = extra_time_;
 
-    ELECHOUSE_cc1101.SpiStrobe(CC1101_SIDLE);
-    while((ELECHOUSE_cc1101.SpiReadStatus(CC1101_MARCSTATE) != MARCSTATE_IDLE));
-    ELECHOUSE_cc1101.SpiStrobe(CC1101_SFTX);  //flush Tx FIFO
-    ELECHOUSE_cc1101.SpiStrobe(CC1101_SFRX);  //flush Rx FIFO
+    cc1101_.strobe(CC1101_SIDLE);
+    while((cc1101_.read_status(CC1101_MARCSTATE) != MARCSTATE_IDLE));
+    cc1101_.strobe(CC1101_SFTX);  //flush Tx FIFO
+    cc1101_.strobe(CC1101_SFRX);  //flush Rx FIFO
 
     // Initialize RX info variable
     rxLoop.lengthField = 0;              // Length Field in the wM-Bus packet
@@ -231,12 +265,12 @@ namespace wmbus {
     data_in.block       = 'X';
 
     // Set Rx FIFO threshold to 4 bytes
-    ELECHOUSE_cc1101.SpiWriteReg(CC1101_FIFOTHR, RX_FIFO_START_THRESHOLD);
-    // Set infinite length 
-    ELECHOUSE_cc1101.SpiWriteReg(CC1101_PKTCTRL0, INFINITE_PACKET_LENGTH);
+    cc1101_.write_register(CC1101_FIFOTHR, RX_FIFO_START_THRESHOLD);
+    // Set infinite length
+    cc1101_.write_register(CC1101_PKTCTRL0, INFINITE_PACKET_LENGTH);
 
-    ELECHOUSE_cc1101.SpiStrobe(CC1101_SRX);
-    while((ELECHOUSE_cc1101.SpiReadStatus(CC1101_MARCSTATE) != MARCSTATE_RX));
+    cc1101_.strobe(CC1101_SRX);
+    while((cc1101_.read_status(CC1101_MARCSTATE) != MARCSTATE_RX));
 
     rxLoop.state = WAIT_FOR_SYNC;
 

--- a/components/wmbus/rf_cc1101.h
+++ b/components/wmbus/rf_cc1101.h
@@ -77,6 +77,19 @@ typedef struct RxLoopData {
 namespace esphome {
 namespace wmbus {
 
+  class Cc1101Driver {
+    public:
+      bool begin(uint8_t mosi, uint8_t miso, uint8_t clk, uint8_t cs);
+      bool set_frequency(float mhz);
+      bool read_frame(uint8_t *buffer, uint8_t length);
+      bool write_register(uint8_t reg, uint8_t value);
+      uint8_t read_status(uint8_t reg);
+      bool strobe(uint8_t cmd);
+      void set_rx();
+      int8_t get_rssi();
+      uint8_t get_lqi();
+  };
+
   class RxLoop {
     public:
       bool init(uint8_t mosi, uint8_t miso, uint8_t clk, uint8_t cs,
@@ -96,6 +109,8 @@ namespace wmbus {
       WMbusFrame returnFrame;
 
       RxLoopData rxLoop;
+
+      Cc1101Driver cc1101_;
 
       uint32_t sync_time_{0};
       uint8_t  extra_time_{50};


### PR DESCRIPTION
## Summary
- add Cc1101Driver wrapper for CC1101 SPI operations
- refactor RxLoop to use Cc1101Driver and log initialization errors

## Testing
- `make test`
- `g++ -std=c++17 -Icomponents/wmbus components/wmbus/rf_cc1101.cpp -c -o /tmp/rf_cc1101.o` *(fails: esphome/core/log.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a786b48ff88326989ea78f1f87438a