### PR TITLE
Add CC1101 transmit support and TX configuration

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -45,6 +45,7 @@ CONF_WMBUS_MQTT_RAW_FORMAT = "mqtt_raw_format"
 CONF_CLIENTS = 'clients'
 CONF_ETH_REF = "wmbus_eth_id"
 CONF_WIFI_REF = "wmbus_wifi_id"
+CONF_ENABLE_TX = "enable_tx"
 
 CODEOWNERS = ["@SzczepanLeon"]
 
@@ -154,6 +155,7 @@ CONFIG_SCHEMA = cv.All(
         cv.Optional(CONF_WMBUS_MQTT_RAW_PREFIX, default=""): cv.string,
         cv.Optional(CONF_WMBUS_MQTT_RAW_FORMAT, default="JSON"): cv.templatable(validate_raw_format),
         cv.Optional(CONF_WMBUS_MQTT_RAW_PARSED, default=True): cv.boolean,
+        cv.Optional(CONF_ENABLE_TX,      default=False):   cv.boolean,
     }),
     validate_mqtt,
 )
@@ -211,6 +213,7 @@ async def to_code(config):
     cg.add(var.set_mqtt_raw_parsed(config[CONF_WMBUS_MQTT_RAW_PARSED]))
 
     cg.add(var.set_log_all(config[CONF_LOG_ALL]))
+    cg.add(var.set_enable_tx(config[CONF_ENABLE_TX]))
 
     for conf in config.get(CONF_CLIENTS, []):
         cg.add(var.add_client(conf[CONF_NAME],

--- a/components/wmbus/rf_cc1101.cpp
+++ b/components/wmbus/rf_cc1101.cpp
@@ -154,6 +154,10 @@ namespace wmbus {
             max_wait_time_    += extra_time_;
           }
           break;
+
+        case TX:
+          // Transmission handled synchronously in transmit(), nothing to do here
+          break;
       }
 
       uint8_t overfl = ELECHOUSE_cc1101.SpiReadStatus(CC1101_RXBYTES) & 0x80;
@@ -186,6 +190,41 @@ namespace wmbus {
 
   WMbusFrame RxLoop::get_frame() {
     return this->returnFrame;
+  }
+
+  bool RxLoop::transmit(const uint8_t *data, size_t len) {
+    if ((data == nullptr) || (len == 0)) {
+      return false;
+    }
+
+    rxLoop.state = TX;
+
+    // Switch to IDLE and flush FIFOs
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_SIDLE);
+    while (ELECHOUSE_cc1101.SpiReadStatus(CC1101_MARCSTATE) != MARCSTATE_IDLE)
+      ;
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_SFRX);
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_SFTX);
+
+    // Load data into TX FIFO
+    ELECHOUSE_cc1101.SpiWriteBurstReg(CC1101_TXFIFO, const_cast<uint8_t *>(data), len);
+
+    // Start transmission
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_STX);
+    // Wait for transmission to start
+    while (ELECHOUSE_cc1101.SpiReadStatus(CC1101_MARCSTATE) != MARCSTATE_TX)
+      ;
+    // Wait for transmission to end
+    while (ELECHOUSE_cc1101.SpiReadStatus(CC1101_MARCSTATE) == MARCSTATE_TX)
+      ;
+
+    ELECHOUSE_cc1101.SpiStrobe(CC1101_SFTX);
+
+    // Restart receiver after transmission
+    rxLoop.state = INIT_RX;
+    start();
+
+    return true;
   }
 
   bool RxLoop::start(bool force) {

--- a/components/wmbus/rf_cc1101.h
+++ b/components/wmbus/rf_cc1101.h
@@ -56,6 +56,7 @@ enum RxLoopState : uint8_t {
   WAIT_FOR_SYNC = 1,
   WAIT_FOR_DATA = 2,
   READ_DATA     = 3,
+  TX            = 4,
 };
 
 enum Cc1101LengthMode : uint8_t {
@@ -83,6 +84,7 @@ namespace wmbus {
                 uint8_t gdo0, uint8_t gdo2, float freq, bool syncMode);
       bool task();
       WMbusFrame get_frame();
+      bool transmit(const uint8_t *data, size_t len);
 
     private:
       bool start(bool force = true);

--- a/components/wmbus/wmbus.h
+++ b/components/wmbus/wmbus.h
@@ -157,6 +157,7 @@ namespace wmbus {
       void set_mqtt_raw_parsed(bool parsed) { this->mqtt_raw_parsed = parsed; }
       void set_mqtt_raw_format(RawFormat format) { this->mqtt_raw_format = format; }
       void set_log_all(bool log_all) { this->log_all_ = log_all; }
+      void set_enable_tx(bool enable_tx) { this->enable_tx_ = enable_tx; }
       void add_client(const std::string name,
                       const network::IPAddress ip,
                       const uint16_t port,
@@ -190,6 +191,7 @@ namespace wmbus {
       uint32_t led_on_millis_{0};
       bool led_on_{false};
       bool log_all_{false};
+      bool enable_tx_{false};
       RxLoop rf_mbus_;
 #ifdef USE_ETHERNET
       ethernet::EthernetComponent *net_component_{nullptr};


### PR DESCRIPTION
## Summary
- add `transmit` API and TX state to CC1101 RxLoop
- switch CC1101 into TX mode, load FIFO and wait for send completion
- expose `enable_tx` option in WMBus component configuration

## Testing
- `cd tests && make test`


------
https://chatgpt.com/codex/tasks/task_e_68a786b620a883269ca9ef5daf932646