### PR TITLE
Support Ethernet builds alongside WiFi

### DIFF
--- a/components/wmbus/wmbus.h
+++ b/components/wmbus/wmbus.h
@@ -30,7 +30,15 @@
 
 #include "utils.h"
 
+#if defined(USE_WIFI)
 #include <WiFi.h>
+using network_client_t = WiFiClient;
+using network_udp_t = WiFiUDP;
+#elif defined(USE_ETHERNET)
+#include <Ethernet.h>
+using network_client_t = EthernetClient;
+using network_udp_t = EthernetUDP;
+#endif
 
 
 namespace esphome {
@@ -181,8 +189,10 @@ namespace wmbus {
       std::vector<RxLoop> rf_mbus_{};
       std::map<uint32_t, WMBusListener *> wmbus_listeners_{};
       std::vector<Client> clients_{};
-      WiFiClient tcp_client_;
-      WiFiUDP udp_client_;
+#if defined(USE_WIFI) || defined(USE_ETHERNET)
+      network_client_t tcp_client_;
+      network_udp_t udp_client_;
+#endif
       time::RealTimeClock *time_{nullptr};
       uint32_t led_blink_time_{0};
       uint32_t led_on_millis_{0};


### PR DESCRIPTION
## Summary
- Wrap WiFi includes and client types in `USE_WIFI`
- Add Ethernet client typedefs for `USE_ETHERNET`

## Testing
- `cd tests && make test` *(fails: TMODE_RF_SETTINGS_LEN not declared)*
- `g++ -std=c++17 -DUSE_WIFI -I/tmp -I/tmp/stubs -Itests/stubs -Icomponents -Icomponents/wmbus -E components/wmbus/wmbus.h -o /tmp/wifi_preprocessed.h`
- `g++ -std=c++17 -DUSE_ETHERNET -I/tmp -I/tmp/stubs -Itests/stubs -Icomponents -Icomponents/wmbus -E components/wmbus/wmbus.h -o /tmp/eth_preprocessed.h`


------
https://chatgpt.com/codex/tasks/task_e_68a796094c108326b6a79206050cb3a2