### PR TITLE
Return const reference from RxLoop::get_frame

### DIFF
--- a/components/wmbus/rf_cc1101.cpp
+++ b/components/wmbus/rf_cc1101.cpp
@@ -8,10 +8,6 @@ namespace wmbus {
   bool Cc1101Driver::begin(uint8_t mosi, uint8_t miso, uint8_t clk, uint8_t cs) {
     ELECHOUSE_cc1101.setSpiPin(clk, miso, mosi, cs);
     ELECHOUSE_cc1101.Init();
-    for (uint8_t i = 0; i < TMODE_RF_SETTINGS_LEN; i++) {
-      ELECHOUSE_cc1101.SpiWriteReg(TMODE_RF_SETTINGS_BYTES[i << 1],
-                                   TMODE_RF_SETTINGS_BYTES[(i << 1) + 1]);
-
     for (const auto &setting : kTmodeConfig) {
       ELECHOUSE_cc1101.SpiWriteReg(setting.reg, setting.val);
     }
@@ -225,7 +221,7 @@ namespace wmbus {
     return rxLoop.complete;
   }
 
-  WMbusFrame RxLoop::get_frame() {
+  const WMbusFrame &RxLoop::get_frame() const {
     return this->returnFrame;
   }
 

--- a/components/wmbus/rf_cc1101.h
+++ b/components/wmbus/rf_cc1101.h
@@ -96,7 +96,7 @@ namespace wmbus {
       bool init(uint8_t mosi, uint8_t miso, uint8_t clk, uint8_t cs,
                 uint8_t gdo0, uint8_t gdo2, float freq, bool syncMode);
       bool task();
-      WMbusFrame get_frame();
+      const WMbusFrame &get_frame() const;
       bool transmit(const uint8_t *data, size_t len);
 
     private:

--- a/components/wmbus/wmbus.cpp
+++ b/components/wmbus/wmbus.cpp
@@ -64,7 +64,7 @@ namespace wmbus {
     for (auto &rf : this->rf_mbus_) {
       if (rf.task()) {
         ESP_LOGVV(TAG, "Have data from RF ...");
-        WMbusFrame mbus_data = rf.get_frame();
+        const WMbusFrame &mbus_data = rf.get_frame();
 
         Telegram t;
         std::string telegram;
@@ -81,7 +81,7 @@ namespace wmbus {
     }
   }
 
-  bool WMBusComponent::parse_telegram(WMbusFrame &mbus_data, Telegram &t, std::string &telegram) {
+  bool WMBusComponent::parse_telegram(const WMbusFrame &mbus_data, Telegram &t, std::string &telegram) {
     telegram = format_hex_pretty(mbus_data.frame);
     telegram.erase(std::remove(telegram.begin(), telegram.end(), '.'), telegram.end());
 
@@ -94,7 +94,7 @@ namespace wmbus {
     return true;
   }
 
-  void WMBusComponent::process_meter(Telegram &t, WMbusFrame &mbus_data, const std::string &telegram) {
+  void WMBusComponent::process_meter(Telegram &t, const WMbusFrame &mbus_data, const std::string &telegram) {
     uint32_t meter_id = (uint32_t) strtoul(t.addresses[0].id.c_str(), nullptr, 16);
     bool meter_in_config = (this->wmbus_listeners_.count(meter_id) == 1) ? true : false;
 
@@ -257,7 +257,7 @@ namespace wmbus {
 
 
 #if defined(USE_WMBUS_MQTT) || defined(USE_MQTT)
-  void WMBusComponent::send_mqtt_raw(Telegram &t, WMbusFrame &mbus_data) {
+  void WMBusComponent::send_mqtt_raw(Telegram &t, const WMbusFrame &mbus_data) {
     bool is_parsed = !t.addresses.empty();
     if (!is_parsed && !this->mqtt_raw_parsed) {
       return;
@@ -323,7 +323,7 @@ namespace wmbus {
   }
 #endif
   
-  void WMBusComponent::send_to_clients(WMbusFrame &mbus_data) {
+  void WMBusComponent::send_to_clients(const WMbusFrame &mbus_data) {
     for (auto & client : this->clients_) {
       switch (client.format) {
         case FORMAT_HEX:

--- a/components/wmbus/wmbus.h
+++ b/components/wmbus/wmbus.h
@@ -169,12 +169,12 @@ namespace wmbus {
     protected:
       const LogString *format_to_string(Format format);
       const LogString *transport_to_string(Transport transport);
-      void send_to_clients(WMbusFrame &mbus_data);
-      void send_mqtt_raw(Telegram &t, WMbusFrame &mbus_data);
+      void send_to_clients(const WMbusFrame &mbus_data);
+      void send_mqtt_raw(Telegram &t, const WMbusFrame &mbus_data);
       void led_blink();
       void led_handler();
-      bool parse_telegram(WMbusFrame &mbus_data, Telegram &t, std::string &telegram);
-      void process_meter(Telegram &t, WMbusFrame &mbus_data, const std::string &telegram);
+      bool parse_telegram(const WMbusFrame &mbus_data, Telegram &t, std::string &telegram);
+      void process_meter(Telegram &t, const WMbusFrame &mbus_data, const std::string &telegram);
       HighFrequencyLoopRequester high_freq_;
       GPIOPin *led_pin_{nullptr};
       std::vector<Cc1101> cc1101_modules_{};

--- a/tests/stubs/ELECHOUSE_CC1101_SRC_DRV.h
+++ b/tests/stubs/ELECHOUSE_CC1101_SRC_DRV.h
@@ -107,6 +107,7 @@ class ELECHOUSE_CC1101 {
       buffer[i] = rx_fifo[rx_fifo_pos++];
     }
   }
+  void SpiWriteBurstReg(uint8_t, uint8_t *, uint8_t) {}
   void SetRx() { marcstate = 0x0D; }
   int getRssi() { return rssi; }
   int getLqi() { return lqi; }


### PR DESCRIPTION
## Summary
- Return a const reference from `RxLoop::get_frame` instead of by value
- Update WMBus handling to work with const `WMbusFrame&` to avoid temporary copies
- Extend CC1101 test stub with burst write support

## Testing
- `cd tests && make test`

------
https://chatgpt.com/codex/tasks/task_e_68a796082a1c83268a0514810d15db88