### PR TITLE
Remove unused WMBus RxLoop member

### DIFF
--- a/components/wmbus/wmbus.h
+++ b/components/wmbus/wmbus.h
@@ -189,7 +189,6 @@ namespace wmbus {
       bool led_on_{false};
       bool log_all_{false};
       bool enable_tx_{false};
-      RxLoop rf_mbus_;
 #ifdef USE_ETHERNET
       ethernet::EthernetComponent *net_component_{nullptr};
 #elif defined(USE_WIFI)


### PR DESCRIPTION
## Summary
- remove obsolete standalone `rf_mbus_` member so the component relies solely on the `rf_mbus_` vector

## Testing
- `make datetime_flags_test && ./datetime_flags_test`
- `make render_analysis_json_test && ./render_analysis_json_test`
- `make driver_apator162_test && ./driver_apator162_test`
- `make rf_cc1101_test` *(fails: TMODE_RF_SETTINGS_LEN not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68a79600d6fc8326a06765535b4bd4fc