### PR TITLE
Remove obsolete CC1101 settings loop

### DIFF
--- a/components/wmbus/rf_cc1101.cpp
+++ b/components/wmbus/rf_cc1101.cpp
@@ -8,10 +8,6 @@ namespace wmbus {
   bool Cc1101Driver::begin(uint8_t mosi, uint8_t miso, uint8_t clk, uint8_t cs) {
     ELECHOUSE_cc1101.setSpiPin(clk, miso, mosi, cs);
     ELECHOUSE_cc1101.Init();
-    for (uint8_t i = 0; i < TMODE_RF_SETTINGS_LEN; i++) {
-      ELECHOUSE_cc1101.SpiWriteReg(TMODE_RF_SETTINGS_BYTES[i << 1],
-                                   TMODE_RF_SETTINGS_BYTES[(i << 1) + 1]);
-
     for (const auto &setting : kTmodeConfig) {
       ELECHOUSE_cc1101.SpiWriteReg(setting.reg, setting.val);
     }

--- a/tests/stubs/ELECHOUSE_CC1101_SRC_DRV.h
+++ b/tests/stubs/ELECHOUSE_CC1101_SRC_DRV.h
@@ -102,11 +102,12 @@ class ELECHOUSE_CC1101 {
     if (addr == CC1101_MARCSTATE) return marcstate;
     return 0;
   }
-  void SpiReadBurstReg(uint8_t, uint8_t *buffer, uint8_t num) {
-    for (uint8_t i = 0; i < num && rx_fifo_pos < rx_fifo_len; ++i) {
-      buffer[i] = rx_fifo[rx_fifo_pos++];
+    void SpiReadBurstReg(uint8_t, uint8_t *buffer, uint8_t num) {
+      for (uint8_t i = 0; i < num && rx_fifo_pos < rx_fifo_len; ++i) {
+        buffer[i] = rx_fifo[rx_fifo_pos++];
+      }
     }
-  }
+    void SpiWriteBurstReg(uint8_t, uint8_t *, uint8_t) {}
   void SetRx() { marcstate = 0x0D; }
   int getRssi() { return rssi; }
   int getLqi() { return lqi; }


### PR DESCRIPTION
## Summary
- remove redundant TMODE_RF_SETTINGS register loop
- add missing SpiWriteBurstReg stub for tests

## Testing
- `make`
- `./datetime_flags_test`
- `./render_analysis_json_test > /dev/null`
- `./driver_apator162_test`
- `./rf_cc1101_test`


------
https://chatgpt.com/codex/tasks/task_e_68a795fc0e108326bee95f477e4e7c83